### PR TITLE
Add an option to EVAL to differentiate eval vs file mode. Python!!!

### DIFF
--- a/lib/Inline/Python.pm6
+++ b/lib/Inline/Python.pm6
@@ -542,7 +542,12 @@ BEGIN {
     PythonObject.^compose;
 }
 
-multi sub EVAL(Cool $code, Str :$lang where { ($lang // '') eq 'Python' }, PseudoStash :$context) is export {
-    state $py = ::("Inline::Python").default_python;
-    $py.run($code);
+multi sub EVAL(
+        Str $code,
+        Str :$lang where { ($lang // '') eq 'Python' },
+        PseudoStash :$context,
+        :$mode = 'eval') is export {
+    my $py = Inline::Python.default_python;
+    CATCH { note $_ }
+    $py.run($code, |($mode eq 'eval' ?? :eval !! :file));
 }

--- a/t/eval.t
+++ b/t/eval.t
@@ -5,12 +5,9 @@ use Inline::Python;
 
 say '1..2';
 
-EVAL 'print "ok 1 - EVAL eval\n"', :from<Python>;
+EVAL 'print "ok 1 - EVAL eval"', :lang<Python>, :mode<file>;
 
 my $py = Inline::Python.new();
-
-$py.run('
-print "ok 2 - direct eval\n";
-', :file);
+$py.run('print "ok 2 - direct eval"', :file);
 
 # vim: ft=perl6

--- a/t/eval_return_values.t
+++ b/t/eval_return_values.t
@@ -4,11 +4,19 @@ use v6;
 use Test;
 use Inline::Python;
 
-plan 3;
+plan 2;
 
-my $py = Inline::Python.new();
-is $py.run('5', :eval), 5;
-is $py.run('u"Python"', :eval), 'Python';
-is $py.run('"Python"', :eval).decode('latin-1'), 'Python';
+subtest {
+    my $py = Inline::Python.new();
+    is $py.run('5', :eval), 5;
+    is $py.run('u"Python"', :eval), 'Python';
+    is $py.run('"Python"', :eval).decode('latin-1'), 'Python';
+}, "Direct run values";
+
+subtest {
+    is EVAL('5', :lang<Python>), 5;
+    is EVAL('u"Python"', :lang<Python>), 'Python';
+    is EVAL('"Python"', :lang<Python>).decode('latin-1'), 'Python';
+}, "EVAL returns values";
 
 # vim: ft=perl6


### PR DESCRIPTION
Turns out the current version doesn't work -- the test was wrong, using :from<Python> instead of :lang<Python. Upon fixing I realized that there are two different EVAL modes for Python. Bleh.

(I wasn't sure how to do the indention for the EVAL signature)