### PR TITLE
Explicitly call python2 in installation

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -6,7 +6,7 @@ use LibraryMake;
 
 class Build is Panda::Builder {
     sub get_config_var(Str $name) {
-        return chomp(qqx/python -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('$name'));"/);
+        return chomp(qqx/python2 -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('$name'));"/);
     }
 
     method build($dir) {

--- a/configure.pl6
+++ b/configure.pl6
@@ -3,7 +3,7 @@ use v6;
 use LibraryMake;
 
 sub get_config_var(Str $name) {
-    return chomp(qqx/python -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('$name'));"/);
+    return chomp(qqx/python2 -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('$name'));"/);
 }
 
 my %vars = get-vars('.');


### PR DESCRIPTION
Some environments have python point to python3. In these
environments the installation fails.