### PR TITLE
Replace '::' with '__' in classes that consume PythonParent role

### DIFF
--- a/lib/Inline/Python.pm6
+++ b/lib/Inline/Python.pm6
@@ -438,8 +438,10 @@ method create_subclass(Str $package, Str $class, Str $subclass_name) {
         .map({"    def {$_.gist}(self, *args): return perl6.invoke(self.__p6_index__, '{$_.gist}', args)"})\
         .join("\n");
     my $baseclass_name = $package eq '__main__' ?? $class !! "$package.$class";
+    my $final_subclass_name = $subclass_name;
+    $final_subclass_name ~~ s:g{'::'} = '__';
     self.run(qq:heredoc/PYTHON/ ~ $methods, :file);
-        class {$subclass_name}($baseclass_name):
+        class {$final_subclass_name}($baseclass_name):
             def __init__(self, i, *args):
                 if i is not None:
                     self.__set_p6_index__(i)
@@ -459,7 +461,9 @@ method create_parent_object(Str $package, Str $class, PythonParent $obj) returns
     my $tuple = py_tuple_new(1);
     my $index = $objects.keep($obj);
     py_tuple_set_item($tuple, 0, self.p6_to_py($index));
-    my $parent = py_call_function($package, $class, $tuple);
+    my $final_class = $class;
+    $final_class ~~ s:g{'::'} = '__';
+    my $parent = py_call_function($package, $final_class, $tuple);
     self.handle_python_exception();
     return self.py_to_p6($parent);
 }

--- a/t/inherit.t
+++ b/t/inherit.t
@@ -4,7 +4,7 @@ use v6;
 use Inline::Python;
 use Test;
 
-plan 8;
+plan 9;
 
 my $py = Inline::Python.new();
 
@@ -60,6 +60,15 @@ class Qux does Inline::Python::PythonParent['__main__', 'PyBar'] {
 }
 
 is((Qux.new().test)(), 'Perl6!!');
+
+class My::Qux does Inline::Python::PythonParent['__main__', 'PyBar'] {
+    method qux() {
+        return "Perl6!!";
+    }
+
+}
+
+is((My::Qux.new().test)(), 'Perl6!!');
 
 # Test passing a Py object to the constructor of a P6 subclass
 


### PR DESCRIPTION
Not sure if replacing :: with __ is the right thing to do on the Python side, also it might be useful to factor out a p6_to_py_class_name method. But at the moment it's a single line, so there's not much to refactor.