### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name" : "Inline::Python",
+    "license" : "Artistic-2.0",
     "version" : "0.3",
     "author" : "github:niner",
     "description" : "Use Python code and libraries in a Perl 6 program",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license