### PR TITLE
Convert Perl6 module name to Python name

### DIFF
--- a/lib/Inline/Python.pm6
+++ b/lib/Inline/Python.pm6
@@ -656,7 +656,7 @@ CompUnit::RepositoryRegistry.use-repository(
                     $RMD("Loading {$spec.short-name} via Inline::Python");
                 }
                 my $handle := $python.import(
-                    $spec.short-name,
+                    $spec.short-name.subst(/\:\:/, '.'),
                 );
                 return CompUnit.new(
                     :short-name($spec.short-name),


### PR DESCRIPTION
Method `import` expects module name separated by `'.'`, so it must be converted.